### PR TITLE
Various GUI Improvements

### DIFF
--- a/Monterey/extraclasses/QROVController/qrovcontroller.cpp
+++ b/Monterey/extraclasses/QROVController/qrovcontroller.cpp
@@ -456,7 +456,7 @@ void QROVController::loadSettings()
 {
     QMutex mutex;
     mutex.lock();
-    //TDOD: Finish adding settings code and remove it from mainwindow.cpp
+    //TODO: Finish adding settings code and remove it from mainwindow.cpp
 
     //Load relay names
     rov->listRelays[0]->setName(mySettings->value("names/relay0", "relay0").toString());

--- a/Monterey/main.cpp
+++ b/Monterey/main.cpp
@@ -27,6 +27,8 @@ int main(int argc, char *argv[])
     QApplication::setApplicationName("Monterey");
     QApplication::setApplicationVersion("3.0 Beta");
     QApplication::setOrganizationName("ROV-Suite");
+
+    // NOTE: Could change this to newer Github website; would break existing settings configurations though
     QApplication::setOrganizationDomain("http://sourceforge.net/p/rov-suite");
 
     FvUpdater::sharedUpdater()->SetFeedURL("https://dl.dropbox.com/u/4649414/ROV-Suite/Appcast.xml");

--- a/Monterey/mainwindow.cpp
+++ b/Monterey/mainwindow.cpp
@@ -536,3 +536,20 @@ void MainWindow::on_vsServo1_valueChanged(int value)
 {
     controller->rov->listServos[1]->setValue(value);
 }
+
+// Copies log to system clipboard for easy sharing
+void MainWindow::on_buttonCopyLogToClipboard_clicked()
+{
+//    This is more of a hack-ish solution
+//    ui->teLog->selectAll();
+//    ui->teLog->copy();
+
+    QClipboard *p_Clipboard = QApplication::clipboard();
+    p_Clipboard->setText(ui->teLog->toPlainText());
+}
+
+// Deletes all log information up to the point when this is clicked
+void MainWindow::on_buttonClearLog_clicked()
+{
+    ui->teLog->clear();
+}

--- a/Monterey/mainwindow.h
+++ b/Monterey/mainwindow.h
@@ -25,6 +25,7 @@
 #include <QLCDNumber>
 #include <QTextEdit>
 #include <QWebView>
+#include <QClipboard>
 
 #include "extraclasses/DepthTape/depthtape.h"
 
@@ -84,6 +85,10 @@ private slots:
     void setupDepthTape();  //!< Configure the depth tape
     void showFullscreen(bool fullscreen);
     void zoomTheCameraFeed(int zoomAmount);
+
+    void on_buttonCopyLogToClipboard_clicked();
+
+    void on_buttonClearLog_clicked();
 
 private:
     QString *version;

--- a/Monterey/mainwindow.ui
+++ b/Monterey/mainwindow.ui
@@ -85,6 +85,28 @@
       </item>
      </layout>
     </item>
+    <item row="1" column="1">
+     <widget class="QSlider" name="zoomSlider">
+      <property name="toolTip">
+       <string>Zoom the camera feed</string>
+      </property>
+      <property name="minimum">
+       <number>0</number>
+      </property>
+      <property name="maximum">
+       <number>1000</number>
+      </property>
+      <property name="value">
+       <number>100</number>
+      </property>
+      <property name="orientation">
+       <enum>Qt::Horizontal</enum>
+      </property>
+      <property name="tickPosition">
+       <enum>QSlider::NoTicks</enum>
+      </property>
+     </widget>
+    </item>
     <item row="0" column="0">
      <layout class="QVBoxLayout" name="verticalLayout_4">
       <item>
@@ -301,7 +323,7 @@
      </layout>
     </item>
     <item row="0" column="2">
-     <layout class="QVBoxLayout" name="verticalLayout_3" stretch="1,0,1,0,3">
+     <layout class="QVBoxLayout" name="verticalLayout_3" stretch="1,0,1,0,3,0">
       <item>
        <widget class="QGroupBox" name="groupBox_3">
         <property name="title">
@@ -714,29 +736,46 @@
         </property>
        </widget>
       </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QPushButton" name="buttonClearLog">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+            <horstretch>1</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>Clears the log from this session of Monterey</string>
+          </property>
+          <property name="text">
+           <string>Clear Log</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="buttonCopyLogToClipboard">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+            <horstretch>1</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>Copies the entire log to the clipboard</string>
+          </property>
+          <property name="text">
+           <string>Copy To Clipboard</string>
+          </property>
+          <property name="flat">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
      </layout>
-    </item>
-    <item row="1" column="1">
-     <widget class="QSlider" name="zoomSlider">
-      <property name="toolTip">
-       <string>Zoom the camera feed</string>
-      </property>
-      <property name="minimum">
-       <number>0</number>
-      </property>
-      <property name="maximum">
-       <number>1000</number>
-      </property>
-      <property name="value">
-       <number>100</number>
-      </property>
-      <property name="orientation">
-       <enum>Qt::Horizontal</enum>
-      </property>
-      <property name="tickPosition">
-       <enum>QSlider::NoTicks</enum>
-      </property>
-     </widget>
     </item>
    </layout>
   </widget>

--- a/Monterey/mainwindow.ui
+++ b/Monterey/mainwindow.ui
@@ -147,6 +147,12 @@
        <layout class="QVBoxLayout" name="verticalLayout_2">
         <item>
          <widget class="QGroupBox" name="groupBox_2">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>2</verstretch>
+           </sizepolicy>
+          </property>
           <property name="title">
            <string>Servos</string>
           </property>
@@ -188,6 +194,12 @@
         </item>
         <item>
          <widget class="QGroupBox" name="groupBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>1</verstretch>
+           </sizepolicy>
+          </property>
           <property name="title">
            <string>Relays</string>
           </property>

--- a/Monterey/mainwindow.ui
+++ b/Monterey/mainwindow.ui
@@ -792,7 +792,6 @@
     <property name="title">
      <string>File</string>
     </property>
-    <addaction name="actionAbout"/>
     <addaction name="actionCheck_for_Updates"/>
     <addaction name="separator"/>
     <addaction name="actionExit"/>
@@ -819,14 +818,21 @@
     <addaction name="separator"/>
     <addaction name="actionDive_Timer_Reset"/>
    </widget>
+   <widget class="QMenu" name="menuHelp">
+    <property name="title">
+     <string>Help</string>
+    </property>
+    <addaction name="actionAbout"/>
+   </widget>
    <addaction name="menuFile"/>
    <addaction name="menuEdit"/>
    <addaction name="menuView"/>
    <addaction name="menuTools"/>
+   <addaction name="menuHelp"/>
   </widget>
   <action name="actionAbout">
    <property name="text">
-    <string>About</string>
+    <string>About Monterey</string>
    </property>
   </action>
   <action name="actionExit">


### PR DESCRIPTION
In addition to the new controls for logging output, I also increased the stretch value for the servo controls, increasing their vertical space when the user expands the window vertically. This could be potentially unwanted behavior if the relay buttons need to be really big. On the other hand, it gives more precise control to the servo's with less vertical space.

The new GUI changes result in this:

![image](https://f.cloud.github.com/assets/4673087/839169/bfa3b616-f339-11e2-9bb1-ee399693eabe.png)

The buttons are still fairly sized with more vertical space: 

![image](https://f.cloud.github.com/assets/4673087/839178/05251ff4-f33a-11e2-8e2e-9305343354e9.png)

In future commits, perhaps the stretch should be more finely-tuned, based on feedback. I also add a note that could serve as a reminder to eventually change the domain if needed.
