### PR TITLE
Added "printsupport" to pro file; seems to be needed for QT 5.3

### DIFF
--- a/Monterey/Monterey.pro
+++ b/Monterey/Monterey.pro
@@ -4,7 +4,7 @@
 #
 #-------------------------------------------------
 
-QT       += core gui network svg widgets quick webkit
+QT       += core gui network svg widgets quick webkit printsupport
 
 CONFIG += c++11
 


### PR DESCRIPTION
Howdy,

Adding this helped prevent a compile error when QPrinter was encountered in Qt 5.3.

OS:  Ubuntu 14.10

Thanks!
